### PR TITLE
Patch ZMQ build on `Linux(:x86_64, libc=:musl, compiler_abi=CompilerABI(:gcc4))` and expand gcc versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,26 @@ env:
   - BINARYBUILDER_AUTOMATIC_APPLE=true
   # Our build takes too long for one job, so split targets across multiple jobs
   matrix:
-    - PART=1/3
-    - PART=2/3
-    - PART=3/3
+    - PART=1/20
+    - PART=2/20
+    - PART=3/20
+    - PART=4/20
+    - PART=5/20
+    - PART=6/20
+    - PART=7/20
+    - PART=8/20
+    - PART=9/20
+    - PART=10/20
+    - PART=11/20
+    - PART=12/20
+    - PART=13/20
+    - PART=14/20
+    - PART=15/20
+    - PART=16/20
+    - PART=17/20
+    - PART=18/20
+    - PART=19/20
+    - PART=20/20
 sudo: required
 jobs:
   include:

--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -8,7 +8,33 @@ sources = [
 
 # Bash recipe for building across all platforms
 script = raw"""
+
 cd $WORKSPACE/srcdir/libzmq
+
+if [[ ${target} == x86_64-linux-musl ]] && [[ $(gcc --version | head -1 | awk '{ print $3 }') == "4.8.5" ]]; then
+
+cat > mm_malloc.patch << 'END'
+--- mm_malloc.h
++++ mm_malloc.h
+@@ -31,7 +31,7 @@
+ #ifndef __cplusplus
+ extern int posix_memalign (void **, size_t, size_t);
+ #else
+-extern "C" int posix_memalign (void **, size_t, size_t) throw ();
++extern "C" int posix_memalign (void **, size_t, size_t);
+ #endif
+
+ static __inline void *
+END
+
+cd /opt/x86_64-linux-musl/lib/gcc/x86_64-linux-musl/4.8.5/include/
+
+patch < "${WORKSPACE}/srcdir/libzmq/mm_malloc.patch"
+
+cd $WORKSPACE/srcdir/libzmq
+
+fi
+
 sh autogen.sh
 ./configure --prefix=$prefix --host=${target} \
     --without-docs --disable-libunwind --disable-perf --disable-Werror \
@@ -21,6 +47,7 @@ make install
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = supported_platforms() # build on all supported platforms
+platforms = expand_gcc_versions(platforms)
 
 # The products that we will ensure are always built
 products(prefix) = [


### PR DESCRIPTION
This PR adds ZMQ builds for `Linux(:x86_64, libc=:musl, compiler_abi=CompilerABI(:gcc4))` by patching a header file before compile.

https://travis-ci.com/kdheepak/ZMQBuilder/jobs/243241217

This PR also expands all gcc versions.